### PR TITLE
Moved open library api call out of explore js and to routes

### DIFF
--- a/routes.py
+++ b/routes.py
@@ -1,8 +1,18 @@
 from flask import Blueprint, request, jsonify, session
+import requests, random
 from models.books import Book, add_book, get_books, create_shelf, add_book_to_shelf, get_user_shelves, update_shelf, remove_book_from_shelf
 #from models.loans import createLoan
 
 books_bp = Blueprint('books', __name__)
+
+CATEGORY_DICT = {
+    "popular": "first_publish_year:2020+subject:ny_times_bestseller",
+    "new": "first_publish_year:[2025 TO 2026]+subject:fiction",
+    "fantasy": "subject:fantasy+subject:ny_times_bestseller",
+    "mystery": "subject:mystery+subject:ny_times_bestseller",
+    "nonfiction": "subject:nonfiction+subject:ny_times_bestseller",
+
+}
 
 @books_bp.route('/add_manual_book', methods=['POST'])
 def add_manual_book():
@@ -110,3 +120,29 @@ def remove_from_shelf():
         return jsonify({"success": True, "message": "Book removed from shelf"})
     return jsonify({"success": False, "message": "Failed to remove the book"}), 400
 
+@books_bp.route('/<category>', methods=['GET'])
+def get_books_by_cat(category):
+    query = CATEGORY_DICT.get(category)
+    if not query:
+        return jsonify({"error": "Category not found"}), 404
+    
+    fields = "title,author_name,cover_i,key,isbn,first_publish_year,cover_edition_key";
+    url = f"https://openlibrary.org/search.json?q={query}&sort=editions&limit=25&fields={fields}";
+
+    try:
+        response = requests.get(url)
+        response.raise_for_status()
+        data = response.json()
+
+        #get the 50 w covers
+        withCovers = [b for b in data.get('docs', []) if b.get('cover_i')]
+
+        #use random to shuffle that list so that not always same 15 grabbed
+        random.shuffle(withCovers)
+
+        finalBooks = withCovers[:15]
+
+        return jsonify(finalBooks)
+
+    except Exception as e:
+        return jsonify({"error": str(e)}), 500

--- a/static/js/explore.js
+++ b/static/js/explore.js
@@ -76,7 +76,7 @@ async function renderBooks(booksArray, container) {
 }
 
 
-async function loadSection(apiUrl, containerId) {
+async function loadSection(category, containerId) {
     const container = document.getElementById(containerId);
     if (!container) return; 
 
@@ -84,31 +84,21 @@ async function loadSection(apiUrl, containerId) {
     container.innerHTML = '<p>Loading books...</p>'; 
 
     try {
-        const response = await fetch(apiUrl);
-        if (!response.ok) throw new Error("Network Error");
-        
-        var data = await response.json();
+        const response = await fetch(`/api/books/${category}`);
+
+        if(!response.ok) throw new Error("server error");
+
+        const finalFifteenBooks = await response.json();
+
         container.innerHTML = '';
-        
-        if (data.docs && data.docs.length > 0) {
-            
-            //dont use books with no coverid
-            const booksWithCovers = data.docs.filter(book => book.cover_i !== undefined);
-            
-            //grab 10 books from the list that filtered out ones missing covers
-            const finalTenBooks = booksWithCovers.slice(0, 10);
 
-            if(finalTenBooks.length > 0) {
-                renderBooks(finalTenBooks, container); 
-            } else {
-                container.innerHTML = '<p>No books with covers found for this section.</p>';
-            }
-
+        if (finalFifteenBooks.length > 0){
+            renderBooks(finalFifteenBooks, container);
         } else {
-            container.innerHTML = '<p>No books found for this section.</p>';
+            container.innerHTML = `<p> No popualr books for category ${category}.</p>`
         }
-
     } catch (err) {
+        console.error(err);
         container.innerHTML = `<p style="color:red">Error loading section.</p>`;
     }
 }
@@ -116,18 +106,14 @@ async function loadSection(apiUrl, containerId) {
 
 window.addEventListener('DOMContentLoaded', () => {
 
-    const popularUrl = `https://openlibrary.org/search.json?q=first_publish_year:2020+subject:ny_times_bestseller&sort=editions&limit=25&fields=title,author_name,cover_i,key,isbn,first_publish_year,cover_edition_key`;
-    loadSection(popularUrl, 'popular-books');
 
-
-    const newReleasesUrl = `https://openlibrary.org/search.json?q=first_publish_year:[2025 TO 2026]+subject:fiction&sort=editions&limit=25&fields=title,author_name,cover_i,key,isbn,first_publish_year,cover_edition_key`;
-    loadSection(newReleasesUrl, 'new-books');
-
-    const fantasyUrl = `https://openlibrary.org/search.json?q=subject:fantasy+subject:ny_times_bestseller&sort=editions&limit=25&fields=title,author_name,cover_i,key,isbn,first_publish_year,cover_edition_key`;
-    loadSection(fantasyUrl, 'fantasy-books');
+    loadSection('popular', 'popular-books');
+    loadSection('new', 'new-books');
+    loadSection('fantasy', 'fantasy-books');
+    loadSection('mystery', 'mystery-books');
+    loadSection('nonfiction', 'nonfic-books');
 
 });
-
 var bookSuggestions = [];
 
 async function searchBooks(searchInput, suggestions)

--- a/templates/explore.html
+++ b/templates/explore.html
@@ -70,7 +70,20 @@
                     <h2>Fantasy</h2>
                     <div id="fantasy-books" class="book-grid"></div>
                 </div>
+           
+
+                <div class="explore-section">
+                    <h2>Mystery</h2>
+                    <div id="mystery-books" class="book-grid"></div>
+                </div>
+
+                <div class="explore-section">
+                    <h2>Nonfiction</h2>
+                    <div id="nonfic-books" class="book-grid"></div>
+                </div>
             </div>
+
+
             
         
         </section>


### PR DESCRIPTION
Needed to add a route to dynamically call the open library api to get the books by genre, added dict in routes for the genres so we can easily add and remove. Added shuffle to shuffle the list of 50 books grabbed with covers, then grab 15 to display. so not the same 15 every time.